### PR TITLE
WA: Explicitly Link Against C++

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -20,4 +20,14 @@ fn main() {
         format!("{}/lib", dst.display())
     );
     println!("cargo:rustc-link-lib=static=protobridge");
+
+    // Explicitly link against C++ to resolve link issues with protobridge.
+    // This does not need to happen on Windows, but Linux and macOS both appear to need it.
+    {
+        #[cfg(target_os = "linux")]
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+
+        #[cfg(target_os = "macos")]
+        println!("cargo:rustc-link-lib=dylib=c++");
+    }
 }


### PR DESCRIPTION
This fixes out-of-the-box builds on Linux and macOS, which had issues related to linking with C++ standard library symbols. It's not clear why we're seeing this, so this is a workaround that fixes the issue quickly.